### PR TITLE
add missing boost/bind header

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -35,6 +35,8 @@
 
 #include <iostream>
 
+#include <boost/bind.hpp>
+
 #include <QAction>
 #include <QApplication>
 #include <QDateTime>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include <boost/bind.hpp>
+
 #include <QDebug>
 #include <QTimer>
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -20,6 +20,8 @@
 #include <wallet/wallet.h>
 #endif
 
+#include <boost/bind.hpp>
+
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDesktopWidget>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -20,6 +20,8 @@
 #include <util.h>
 #include <wallet/wallet.h>
 
+#include <boost/bind.hpp>
+
 #include <QColor>
 #include <QDateTime>
 #include <QDebug>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -31,6 +31,8 @@
 
 #include <stdint.h>
 
+#include <boost/bind.hpp>
+
 #include <QDebug>
 #include <QMessageBox>
 #include <QSet>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -48,6 +48,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/bind.hpp>
 #include <boost/thread.hpp>
 
 #if defined(NDEBUG)

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
newer version of boost have a different header layout, making this one needed unless various small migration paths are taken.
it still produces a warning around missing namespaces, but that's consistent with the rest of the project for now.

i keep updating this as i find more files during build.